### PR TITLE
Fix inconsistent table literal padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ end
 
 function myclass.new()
    local self = {}
-   setmetatable(self, { __index = MyClass })
+   setmetatable(self, {__index = MyClass})
    return self
 end
 


### PR DESCRIPTION
Looking at the examples, table literals should not be padded (incorrect `t = { a = 1 }` vs correct `t = {a=1}`). There was an example in the OOP section that did have padding, so I took it away to make it consistent with the other examples.

Perhaps this padding-vs-no-padding recommendation could be noted explicitly in the style guide?